### PR TITLE
Use ensure_connection to allow broker failover

### DIFF
--- a/kombu/__init__.py
+++ b/kombu/__init__.py
@@ -7,7 +7,7 @@ version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
 )
 
-VERSION = version_info_t(3, 0, 26, '', '')
+VERSION = version_info_t(3, 0, 26.1, '', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -753,7 +753,7 @@ class Connection(object):
 
         """
         # make sure we're still connected, and if not refresh.
-        self.connection
+        self.ensure_connection()
         if self._default_channel is None:
             self._default_channel = self.channel()
         return self._default_channel


### PR DESCRIPTION
Just cherry picking a commit from kombu's current master to ensure workers would re-connect if broker nodes failed.